### PR TITLE
feature: verify that split keys have not changed splits between runs

### DIFF
--- a/{{cookiecutter.repository_name}}/guild.yml
+++ b/{{cookiecutter.repository_name}}/guild.yml
@@ -61,6 +61,7 @@
       sources:
         - operation: prepare
     splits:
+      path: {{cookiecutter.package_name}}
       sources:
         - {{cookiecutter.package_name}}/splits
     notebooks:

--- a/{{cookiecutter.repository_name}}/operations/evaluate.py
+++ b/{{cookiecutter.repository_name}}/operations/evaluate.py
@@ -17,6 +17,7 @@ def evaluate(config):
     model = architecture.Model().to(device)
 
     if Path("model").exists():
+        tools.verify_splits()
         print("Loading model checkpoint")
         model.load_state_dict(torch.load("model/model.pt"))
 

--- a/{{cookiecutter.repository_name}}/operations/train.py
+++ b/{{cookiecutter.repository_name}}/operations/train.py
@@ -26,6 +26,7 @@ def train(config):
     optimizer = torch.optim.Adam(model.parameters(), lr=config["learning_rate"])
 
     if Path("model").exists():
+        tools.verify_splits()
         print("Loading model checkpoint")
         model.load_state_dict(torch.load("model/model.pt"))
         optimizer.load_state_dict(torch.load("model/optimizer.pt"))

--- a/{{cookiecutter.repository_name}}/{{cookiecutter.package_name}}/tools/__init__.py
+++ b/{{cookiecutter.repository_name}}/{{cookiecutter.package_name}}/tools/__init__.py
@@ -1,2 +1,3 @@
 from {{cookiecutter.package_name}}.tools.text_ import text_
 from {{cookiecutter.package_name}}.tools.unzip import unzip
+from {{cookiecutter.package_name}}.tools.verify_splits import verify_splits

--- a/{{cookiecutter.repository_name}}/{{cookiecutter.package_name}}/tools/verify_splits.py
+++ b/{{cookiecutter.repository_name}}/{{cookiecutter.package_name}}/tools/verify_splits.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+
+def verify_splits():
+    previous_splits = {
+        path.name: json.loads(path.read_text())
+        for path in Path("model/{{cookiecutter.package_name}}/splits").glob("*.json")
+    }
+
+    current_splits = {
+        path.name: json.loads(path.read_text())
+        for path in Path("{{cookiecutter.package_name}}/splits").glob("*.json")
+    }
+
+    if len(set(previous_splits.keys()) - set(current_splits.keys())) > 0:
+        print("Some split files are missing in the current splits")
+        return False
+
+    checks = [
+        dict(
+            previous_split_name=previous_split_name,
+            current_split_name=current_split_name,
+            file_name=file_name,
+            overlap=len(set(previous_keys).intersection(set(current_keys))) > 0,
+        )
+        for file_name, previous_split in previous_splits.items()
+        for previous_split_name, previous_keys in previous_split.items()
+        for current_split_name, current_keys in current_splits[file_name].items()
+        if previous_split_name != current_split_name
+    ]
+
+    for check in checks:
+        if check["overlap"]:
+            print(
+                f"Some keys from previous split \"{check['previous_split_name']}\""
+                f" are present in current split \"{check['current_split_name']}\""
+                f" from \"{check['file_name']}\""
+            )
+
+    return not any([check["overlap"] for check in checks])


### PR DESCRIPTION
Questions:
- Should it take path arguments?
- Should it either
1. print a warning
2. raise a warning
3. raise an exception
4. print/raise nothing and just return a boolean