### PR TITLE
Jupyter op updates

### DIFF
--- a/{{cookiecutter.repository_name}}/operations/jupyter.py
+++ b/{{cookiecutter.repository_name}}/operations/jupyter.py
@@ -7,10 +7,14 @@ from pathlib import Path
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=8888)
+    parser.add_argument("--notebook", type=str, default="")
+    parser.add_argument("--no-browser", action="store_true")
     args = parser.parse_args()
 
     working_dir = f"{os.environ['GUILD_HOME']}/runs/{os.environ['RUN_ID']}"
-    command = f"jupyter notebook --port={args.port}"
+    command = f"jupyter notebook {args.notebook} --port={args.port}"
+    if args.no_browser:
+        command += " --no-browser"
     os.environ["PYTHONPATH"] += os.environ["PROJECT_DIR"] + ":"
 
     if "PYTHONSTARTUP" in os.environ and Path(os.environ["PYTHONSTARTUP"]).exists():

--- a/{{cookiecutter.repository_name}}/operations/jupyter.py
+++ b/{{cookiecutter.repository_name}}/operations/jupyter.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
 
     working_dir = f"{os.environ['GUILD_HOME']}/runs/{os.environ['RUN_ID']}"
     command = f"jupyter notebook --port={args.port}"
+    os.environ["PYTHONPATH"] += os.environ["PROJECT_DIR"] + ":"
 
     if "PYTHONSTARTUP" in os.environ and Path(os.environ["PYTHONSTARTUP"]).exists():
         python_startup_script = (


### PR DESCRIPTION
- Explicitly adds `PROJECT_DIR` to `PYTHONPATH`
- `notebook` argument (useful if you want to just go directly into a notebook and bypass the working tree selection)
- `no-browser` argument (useful if you're reloading jupyter a bunch with different resources and don't want to open/close tabs)